### PR TITLE
Order reply tree by score

### DIFF
--- a/app/components/ui/feed.tsx
+++ b/app/components/ui/feed.tsx
@@ -30,7 +30,7 @@ export function Feed({
 				return (
 					<div key={post.id}>
 						{!directReply &&
-							post.parent &&
+							post.parent !== null &&
 							(followsParent ? (
 								<div className="link-to-parent threadline" />
 							) : (

--- a/app/routes/tags+/$tag.stats.$postId.tsx
+++ b/app/routes/tags+/$tag.stats.$postId.tsx
@@ -12,6 +12,7 @@ import {
 	getScoredPost,
 	getEffectOnParent,
 } from '#app/ranking.ts'
+import { getOrInsertTagId } from '#app/tag.ts'
 import { relativeEntropy } from '#app/utils/entropy.ts'
 
 const postIdSchema = z.coerce.number()


### PR DESCRIPTION
- fix(ci): lint & format, move typecheck to same job
- run on pr
- fix workflow file
- format
- use spaces instead of tabs
- Revert "use spaces instead of tabs"
- Upgrade prettier and eslint-plugin-prettier
- Just lint only runs lint. Remove just format
- Run just lint, which not also runns prettier
- only run eslint in ci
- fix justfile and run it
- Run just lint
- add .mergify.yml
- Delete all code an tables related to attention tracking
- Fix code to query reply tree in order of strength of effect
